### PR TITLE
Fix Test Script Path and File Reference Issues

### DIFF
--- a/test/test-immediate-execution.sh
+++ b/test/test-immediate-execution.sh
@@ -3,8 +3,8 @@
 # Test script to execute task immediately without waiting for renewal window
 
 LOG_FILE="${CLAUDE_NIGHTS_WATCH_DIR:-$(pwd)}/logs/claude-nights-watch-test.log"
-TASK_FILE="test-todo-tasks.md"
-RULES_FILE="test-todo-rules.md"
+TASK_FILE="${TASK_FILE:-task.md}"
+RULES_FILE="${RULES_FILE:-rules.md}"
 TASK_DIR="${CLAUDE_NIGHTS_WATCH_DIR:-$(pwd)}"
 
 # Ensure logs directory exists

--- a/test/test-simple.sh
+++ b/test/test-simple.sh
@@ -25,7 +25,7 @@ echo ""
 
 # Run the test
 echo "Running test execution..."
-./test-immediate-execution.sh
+./test/test-immediate-execution.sh
 
 # Restore original files
 mv task.md.bak task.md 2>/dev/null || true


### PR DESCRIPTION
## Summary

Fixed two issues in the test scripts that were preventing the simple test from running successfully:

1. **Fixed incorrect path reference in test-simple.sh** - The script was trying to execute `./test-immediate-execution.sh` from the root directory, but the script is located in the `test/` directory.

2. **Made task and rules file names configurable in test-immediate-execution.sh** - The execution script was hardcoded to look for specific test files (`test-todo-tasks.md` and `test-todo-rules.md`) instead of using the files that `test-simple.sh` actually sets up.

## Changes

### test/test-simple.sh
- Changed `./test-immediate-execution.sh` to `./test/test-immediate-execution.sh` to reference the correct path

### test/test-immediate-execution.sh  
- Replaced hardcoded file names with environment variable fallbacks:
  - `TASK_FILE="test-todo-tasks.md"` → `TASK_FILE="${TASK_FILE:-task.md}"`
  - `RULES_FILE="test-todo-rules.md"` → `RULES_FILE="${RULES_FILE:-rules.md}"`

## Impact

The test suite now works correctly. The `test-simple.sh` script can successfully:
1. Set up test files by copying them to `task.md` and `rules.md`
2. Execute the immediate execution script which now finds the correct files
3. Clean up by restoring the original files

This enables proper testing of the Claude Nights Watch functionality.