### PR TITLE
Fix Daemon Startup Issue When Run from Different Directories

### DIFF
--- a/claude-nights-watch-manager.sh
+++ b/claude-nights-watch-manager.sh
@@ -3,13 +3,12 @@
 # Claude Nights Watch Manager - Start, stop, and manage the task execution daemon
 
 DAEMON_SCRIPT="$(cd "$(dirname "$0")" && pwd)/claude-nights-watch-daemon.sh"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PID_FILE="$SCRIPT_DIR/logs/claude-nights-watch-daemon.pid"
-LOG_FILE="$SCRIPT_DIR/logs/claude-nights-watch-daemon.log"
-START_TIME_FILE="$SCRIPT_DIR/logs/claude-nights-watch-start-time"
+TASK_DIR="${CLAUDE_NIGHTS_WATCH_DIR:-$(pwd)}"
+PID_FILE="$TASK_DIR/logs/claude-nights-watch-daemon.pid"
+LOG_FILE="$TASK_DIR/logs/claude-nights-watch-daemon.log"
+START_TIME_FILE="$TASK_DIR/logs/claude-nights-watch-start-time"
 TASK_FILE="task.md"
 RULES_FILE="rules.md"
-TASK_DIR="${CLAUDE_NIGHTS_WATCH_DIR:-$(pwd)}"
 
 # Colors for output
 RED='\033[0;31m'

--- a/view-logs.sh
+++ b/view-logs.sh
@@ -3,7 +3,8 @@
 # Claude Nights Watch Log Viewer
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-LOG_DIR="$SCRIPT_DIR/logs"
+TASK_DIR="${CLAUDE_NIGHTS_WATCH_DIR:-$(pwd)}"
+LOG_DIR="$TASK_DIR/logs"
 
 # Colors
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Problem

The Claude Nights Watch daemon would fail to start when the manager script was executed from a directory other than where the scripts are located. This happened because log files were being created relative to the script location (`SCRIPT_DIR`) rather than the task directory where the daemon should operate.

## Root Cause

The manager and log viewer scripts were using `SCRIPT_DIR` for log file paths:
- `PID_FILE="$SCRIPT_DIR/logs/claude-nights-watch-daemon.pid"`
- `LOG_FILE="$SCRIPT_DIR/logs/claude-nights-watch-daemon.log"`
- `LOG_DIR="$SCRIPT_DIR/logs"`

This caused issues when:
1. Running the daemon from a different directory than where the scripts are installed
2. The `CLAUDE_NIGHTS_WATCH_DIR` environment variable is set to a different location
3. Multiple project directories need separate daemon instances

## Solution

Updated both scripts to use `TASK_DIR` (derived from `CLAUDE_NIGHTS_WATCH_DIR` or current working directory) instead of `SCRIPT_DIR` for log file locations.

### Changes Made

#### claude-nights-watch-manager.sh
- Moved `TASK_DIR` definition to the top for clarity
- Updated log file paths to use `$TASK_DIR/logs/` instead of `$SCRIPT_DIR/logs/`:
  - `PID_FILE="$TASK_DIR/logs/claude-nights-watch-daemon.pid"`
  - `LOG_FILE="$TASK_DIR/logs/claude-nights-watch-daemon.log"`
  - `START_TIME_FILE="$TASK_DIR/logs/claude-nights-watch-start-time"`

#### view-logs.sh
- Added `TASK_DIR` variable using `CLAUDE_NIGHTS_WATCH_DIR` environment variable
- Updated `LOG_DIR` to use `$TASK_DIR/logs/` instead of `$SCRIPT_DIR/logs/`

## Impact

- ✅ Daemon now starts correctly when run from any directory
- ✅ Log files are created in the appropriate task directory
- ✅ Multiple project instances can run independently
- ✅ `CLAUDE_NIGHTS_WATCH_DIR` environment variable works as expected
- ✅ Maintains backward compatibility when run from script directory

## Testing

The daemon can now be started successfully from any directory:
```bash
cd /path/to/any/project
/path/to/claude-nights-watch-manager.sh start
```

Log files will be created in the correct location relative to the task directory, not the script location.
